### PR TITLE
fix issue that is caused by concurrent creation of Github Issues

### DIFF
--- a/fixes/helpers/github-issue-create-helpers.js
+++ b/fixes/helpers/github-issue-create-helpers.js
@@ -64,7 +64,7 @@ async function ensureAddedGithubLabels(
         })
       }
     } catch (error) {
-      if (error.status != 422 && error.errors[0].code != 'already_exists') {
+      if (error.status != 422 && errors.errors != undefined && error.errors[0].code != 'already_exists') {
         console.error(error)
       }
     }

--- a/fixes/helpers/github-issue-create-helpers.js
+++ b/fixes/helpers/github-issue-create-helpers.js
@@ -64,7 +64,9 @@ async function ensureAddedGithubLabels(
         })
       }
     } catch (error) {
-      console.error(error)
+      if (error.status != 422 && error.errors[0].code != 'already_exists') {
+        console.error(error)
+      }
     }
   }
 }
@@ -89,9 +91,8 @@ async function doesLabelExistOnRepo(targetOrg, repo, label, octokit) {
   } catch (error) {
     if (error.status === 404) {
       return false
-    } else {
-      console.error(error)
     }
+    console.error(error)
   }
   return true
 }

--- a/fixes/helpers/github-issue-create-helpers.js
+++ b/fixes/helpers/github-issue-create-helpers.js
@@ -64,7 +64,11 @@ async function ensureAddedGithubLabels(
         })
       }
     } catch (error) {
-      if (error.status != 422 && errors.errors != undefined && error.errors[0].code != 'already_exists') {
+      if (
+        error.status !== 422 &&
+        error.errors !== undefined &&
+        error.errors[0].code !== 'already_exists'
+      ) {
         console.error(error)
       }
     }


### PR DESCRIPTION
Fix issue that is caused by concurrent creation of Github Issues
This issue occurs when creating new labels concurrently for different rules. This would result in Github giving out a 422 error with a message that the Label already exists. This commit works around this concurrency problem by catching the error and checking the message.
